### PR TITLE
Unifie la variable JWT_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-SECRET_KEY=changeme
 DATABASE_URL=postgresql://postgres:postgres@db:5432/crypto_db
 JWT_SECRET=your_jwt_secret_here
 BINANCE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Application web personnelle de suivi des comptes crypto et wallet avec agrégati
 
 ## ▶️ Lancer le projet
 
+Copier `.env.example` vers `.env` et renseigner la variable `JWT_SECRET` pour
+signer les tokens JWT.
+
 ```bash
 docker compose up --build
 ```

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 import os
 
-SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+SECRET_KEY = os.getenv("JWT_SECRET", "secret")
 ALGORITHM = "HS256"
 
 def decode_access_token(token: str):


### PR DESCRIPTION
## Notes
- adoption d'un nom unique `JWT_SECRET` pour la clé JWT
- nettoyage du `.env.example` et mise à jour de la documentation

## Testing
- `python -m py_compile backend/app/core/auth.py backend/app/core/security.py backend/app/core/deps.py`
- `find backend -name '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_684b4ad24860832397afcbf519f1886b