### PR TITLE
Implement refresh logs history endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Added `/refresh-logs` endpoint to retrieve refresh history for authenticated users.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Ce document trace l’ensemble des étapes prévues pour développer l’applica
 
 ## 📌 **Statut actuel**
 
-Phase 5 validée (Fetch engine réel) ✅
+Phase 6 validée (Historique des refreshs) ✅
 
 ---
 
@@ -34,7 +34,7 @@ Phase 5 validée (Fetch engine réel) ✅
 * [x] **Phase 3 :** Authentification mono-utilisateur (JWT)
 * [x] **Phase 4 :** Dashboard dummy (backend route, front minimal, affichage JSON)
 * [x] **Phase 5 :** Fetch engine réel
-* [ ] **Phase 6 :** Historique des refreshs
+* [x] **Phase 6 :** Historique des refreshs
 * [ ] **Phase 7 :** UI avancée (SPA Vue, graphiques)
 * [ ] **Phase 8 :** Tâches périodiques & scheduler
 * [ ] **Phase 9 :** CI/CD + tests

--- a/backend/app/api/routes/refresh.py
+++ b/backend/app/api/routes/refresh.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+from typing import List
 import json
 
 from app.core.deps import get_current_user
@@ -7,6 +8,7 @@ from app.db.session import get_db
 from app.models.user import User
 from app.models.account import Account
 from app.models.refresh_log import RefreshLog
+from app.schemas.refresh_log import RefreshLogRead
 from app.services.fetchers import FETCHERS
 
 router = APIRouter(tags=["refresh"])
@@ -39,3 +41,30 @@ def refresh_accounts(db: Session = Depends(get_db), current_user: User = Depends
         db.add(log)
     db.commit()
     return {"status": "ok", "results": results}
+
+
+@router.get("/refresh-logs", response_model=List[RefreshLogRead])
+def get_refresh_logs(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return the full refresh history for the authenticated user.
+
+    Example response:
+    [
+        {
+            "id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+            "provider": "binance",
+            "success": true,
+            "raw_data": "{...}",
+            "created_at": "2025-06-07T22:00:00Z"
+        }
+    ]
+    """
+
+    return (
+        db.query(RefreshLog)
+        .filter(RefreshLog.user_id == current_user.id)
+        .order_by(RefreshLog.created_at.desc())
+        .all()
+    )

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -1,5 +1,5 @@
 from app.db.session import engine
-from app.models import user, account  # importe tous les modèles pour enregistrer les métadonnées
+from app.models import user, account, refresh_log  # importe tous les modèles pour enregistrer les métadonnées
 from app.models.user import Base  # ou depuis db.base_class
 
 def init_db():

--- a/backend/app/schemas/refresh_log.py
+++ b/backend/app/schemas/refresh_log.py
@@ -1,0 +1,18 @@
+# backend/app/schemas/refresh_log.py
+
+from pydantic import BaseModel
+from uuid import UUID
+from datetime import datetime
+
+
+class RefreshLogRead(BaseModel):
+    """Schema for refresh log entries returned by the API."""
+
+    id: UUID
+    provider: str
+    success: bool
+    raw_data: str
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add API schema for refresh logs
- expose `/refresh-logs` endpoint secured with JWT
- ensure refresh_log table is created by init_db
- update roadmap status and add changelog entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c9a89420832396c6dd87d5093b88